### PR TITLE
Add payment reference, other improvements

### DIFF
--- a/contracts/Unicrow.sol
+++ b/contracts/Unicrow.sol
@@ -48,8 +48,9 @@ contract Unicrow is ReentrancyGuard, IUnicrow, Context {
      * @param arbitrator Address of an arbitrator (zero is returned if no arbitrator was defined)
      * @param arbitratorFee Arbitrator's fee in bips
      * @param challengePeriod Initial challenge period in seconds
+     * @param paymentReference Payment or order reference
      */
-    event Pay(uint256 indexed escrowId, uint256 blockTime, Escrow escrow, address arbitrator, uint256 arbitratorFee, uint256 challengePeriod);
+    event Pay(uint256 indexed escrowId, uint256 blockTime, Escrow escrow, address arbitrator, uint256 arbitratorFee, uint256 challengePeriod, string paymentReference);
 
     /**
      * @notice Emitted when the buyer releases the payment manually (regardless of the challenge period)
@@ -199,7 +200,8 @@ contract Unicrow is ReentrancyGuard, IUnicrow, Context {
             challengeExtension: uint64(input.challengeExtension > 0 ? input.challengeExtension : input.challengePeriod),
             challengePeriodStart: uint64(block.timestamp), //challenge start
             challengePeriodEnd: uint64(block.timestamp + input.challengePeriod), //chalenge end
-            amount: amount
+            amount: amount,
+            paymentReference: input.paymentReference
         });
 
         // Store the escrow information
@@ -208,10 +210,10 @@ contract Unicrow is ReentrancyGuard, IUnicrow, Context {
         // Increase the escrow id counter
         escrowIdCounter.increment();
 
-        emit Pay(escrowId, block.timestamp, escrow, arbitrator, arbitratorFee, input.challengePeriod);
+        emit Pay(escrowId, block.timestamp, escrow, arbitrator, arbitratorFee, input.challengePeriod, input.paymentReference);
     
         return escrowId;
-}
+    }
 
     /// @inheritdoc IUnicrow
     function refund(uint256 escrowId) external override nonReentrant {

--- a/contracts/Unicrow.sol
+++ b/contracts/Unicrow.sol
@@ -48,9 +48,8 @@ contract Unicrow is ReentrancyGuard, IUnicrow, Context {
      * @param arbitrator Address of an arbitrator (zero is returned if no arbitrator was defined)
      * @param arbitratorFee Arbitrator's fee in bips
      * @param challengePeriod Initial challenge period in seconds
-     * @param paymentReference Payment or order reference
      */
-    event Pay(uint256 indexed escrowId, uint256 blockTime, Escrow escrow, address arbitrator, uint256 arbitratorFee, uint256 challengePeriod, string paymentReference);
+    event Pay(uint256 indexed escrowId, uint256 blockTime, Escrow escrow, address arbitrator, uint256 arbitratorFee, uint256 challengePeriod);
 
     /**
      * @notice Emitted when the buyer releases the payment manually (regardless of the challenge period)
@@ -210,7 +209,7 @@ contract Unicrow is ReentrancyGuard, IUnicrow, Context {
         // Increase the escrow id counter
         escrowIdCounter.increment();
 
-        emit Pay(escrowId, block.timestamp, escrow, arbitrator, arbitratorFee, input.challengePeriod, input.paymentReference);
+        emit Pay(escrowId, block.timestamp, escrow, arbitrator, arbitratorFee, input.challengePeriod);
     
         return escrowId;
     }

--- a/contracts/UnicrowArbitrator.sol
+++ b/contracts/UnicrowArbitrator.sol
@@ -175,15 +175,19 @@ contract UnicrowArbitrator is IUnicrowArbitrator, Context, ReentrancyGuard {
     }
 
     /// @inheritdoc IUnicrowArbitrator
-    function arbitrate(uint256 escrowId, uint16[2] calldata newSplit)
-        external
-        override
-    {
+    function arbitrate(
+        uint256 escrowId, 
+        uint16[2] calldata newSplit
+    ) external override returns (uint256[5] memory) {
         Arbitrator memory arbitratorData = getArbitratorData(escrowId);
         Escrow memory escrow = unicrow.getEscrow(escrowId);
 
-        // Check that this is this escrow's arbitrator calling
-        require(_msgSender() == arbitratorData.arbitrator, "2-005");
+        // Check that this is this escrow's arbitrator or a contract acting on behalf of arbitrator calling directly
+        require(
+            _msgSender() == arbitratorData.arbitrator ||
+                tx.origin == arbitratorData.arbitrator,
+            "2-005"
+        );
         
         // Check that the arbitrator was set by mutual consensus
         require(
@@ -217,6 +221,8 @@ contract UnicrowArbitrator is IUnicrowArbitrator, Context, ReentrancyGuard {
         uint256[5] memory amounts = unicrowClaim.claim(escrowId);
 
         emit Arbitrated(escrowId, escrow, block.timestamp, amounts);
+
+        return amounts;
     }
 
     /**

--- a/contracts/UnicrowTypes.sol
+++ b/contracts/UnicrowTypes.sol
@@ -67,6 +67,9 @@ struct Escrow {
 
     /// @dev amount in the token
     uint256 amount;
+
+    /// @dev Optional text reference can be used to identify the payment or provide information for an arbitrator
+    string paymentReference;
 }
 
 /// @dev Escrow parameters to be sent along with the deposit
@@ -91,6 +94,9 @@ struct EscrowInput {
 
     /// @dev Amount in token
     uint256 amount;
+
+    /// @dev Optional text reference can be used to identify the payment or provide information for an arbitrator
+    string paymentReference;
 }
 
 /// @dev Information about arbitrator proposed or assigned to an escrow.

--- a/contracts/interfaces/IUnicrow.sol
+++ b/contracts/interfaces/IUnicrow.sol
@@ -19,7 +19,7 @@ interface IUnicrow {
     EscrowInput memory input,
     address arbitrator,
     uint16 arbitratorFee
-  ) external payable;
+  ) external payable returns (uint256);
 
   /**
    * @notice Function called by UnicrowDispute to execute a challenge

--- a/contracts/interfaces/IUnicrowArbitrator.sol
+++ b/contracts/interfaces/IUnicrowArbitrator.sol
@@ -36,7 +36,7 @@ interface IUnicrowArbitrator {
      * @param escrowId Id of an escrow
      * @param newSplit How the payment should be split between buyer [0] and seller [1]. [100, 0] will refund the payment to the buyer, [0, 100] will release it to the seller, anything in between will
      */
-    function arbitrate(uint256 escrowId, uint16[2] memory newSplit) external;
+    function arbitrate(uint256 escrowId, uint16[2] memory newSplit) external returns (uint256[5] memory);
 
     /**
      * Get information about proposed or assigned arbitrator.


### PR DESCRIPTION
- Add paymentReference field in the escrow contract (EscrowInput, Escrow)
- Unicrow.pay() function returns escrow ID
- Arbitrator can call Unicrow.refund(), which will refund also their fee
- UnicrowArbitrator.arbitrate() returns final amounts the same way as UnicrowDispute.approveSettlement()